### PR TITLE
style: replace double quotes with single quotes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,7 @@ exclude = .git,.venv/,__pycache__,build,dist
 ignore = D107, D200, D400, D401, E203, W503
 per-file-ignores =
     tests/test_*.py:D102
+    synology_office_exporter/__main__.py:D100
+inline-quotes = single
+multiline-quotes = single
+docstring-quotes = double

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "autopep8",
+    "flake8",
+    "flake8-quotes",
     "build",
     "twine",
     "flake8>=7.1.2",

--- a/synology_office_exporter/__main__.py
+++ b/synology_office_exporter/__main__.py
@@ -1,5 +1,5 @@
 import sys
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     from synology_office_exporter.cli import main
     sys.exit(main())

--- a/synology_office_exporter/cli.py
+++ b/synology_office_exporter/cli.py
@@ -82,15 +82,15 @@ def main():  # noqa: D103
 
     # If still missing credentials, prompt the user
     if not username:
-        username = input("Synology username: ")
+        username = input('Synology username: ')
     if not password:
-        password = getpass.getpass("Synology password: ")
+        password = getpass.getpass('Synology password: ')
     if not server:
-        server = input("Synology server URL: ")
+        server = input('Synology server URL: ')
 
     # Check if all required credentials are set
     if not all([username, password, server]):
-        logging.error("Missing credentials. Please provide username, password, and server.")
+        logging.error('Missing credentials. Please provide username, password, and server.')
         return 1
 
     try:
@@ -105,12 +105,12 @@ def main():  # noqa: D103
                 exporter.download_teamfolder_files()
             print(stat_buf.getvalue())
 
-        logging.info("Done!")
+        logging.info('Done!')
         return 0
     except DownloadHistoryError as e:
-        logging.error("Error occurred while loading download history file.")
-        print(f"Error: Problem with download history file - {e}", file=sys.stderr)
+        logging.error('Error occurred while loading download history file.')
+        print(f'Error: Problem with download history file - {e}', file=sys.stderr)
         return 1
     except Exception as e:
-        logging.error(f"Error: {e}")
+        logging.error(f'Error: {e}')
         return 1

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -17,32 +17,32 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         """Set up test environment before each test."""
         # Create a mock SynologyDriveEx instance
         self.mock_synd = MagicMock()
-        self.output_dir = "/tmp/synology_office_exports"
+        self.output_dir = '/tmp/synology_office_exports'
 
     def test_get_offline_name(self):
         """Test conversion of Synology Office filenames to MS Office filenames."""
         self.assertEqual(
-            SynologyOfficeExporter.get_offline_name("document.odoc"),
-            "document.docx"
+            SynologyOfficeExporter.get_offline_name('document.odoc'),
+            'document.docx'
         )
         self.assertEqual(
-            SynologyOfficeExporter.get_offline_name("spreadsheet.osheet"),
-            "spreadsheet.xlsx"
+            SynologyOfficeExporter.get_offline_name('spreadsheet.osheet'),
+            'spreadsheet.xlsx'
         )
         self.assertEqual(
-            SynologyOfficeExporter.get_offline_name("presentation.oslides"),
-            "presentation.pptx"
+            SynologyOfficeExporter.get_offline_name('presentation.oslides'),
+            'presentation.pptx'
         )
         self.assertIsNone(
-            SynologyOfficeExporter.get_offline_name("not_office_file.txt")
+            SynologyOfficeExporter.get_offline_name('not_office_file.txt')
         )
 
-    @patch("os.makedirs")
-    @patch("builtins.open", new_callable=mock_open)
+    @patch('os.makedirs')
+    @patch('builtins.open', new_callable=mock_open)
     def test_save_bytesio_to_file(self, mock_file_open, mock_makedirs):
         """Test saving BytesIO content to a file."""
-        test_content = b"test content"
-        test_path = os.path.join(self.output_dir, "test.docx")
+        test_content = b'test content'
+        test_path = os.path.join(self.output_dir, 'test.docx')
 
         # Create BytesIO with test content
         data = BytesIO(test_content)
@@ -58,8 +58,8 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         # Verify content was written
         mock_file_open().write.assert_called_once_with(test_content)
 
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("json.dump")
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.dump')
     def test_save_download_history(self, mock_json_dump, mock_file_open):
         """Test that download history is saved correctly."""
         with patch.object(SynologyOfficeExporter, '_load_download_history'):
@@ -75,10 +75,10 @@ class TestSynologyOfficeExporter(unittest.TestCase):
 
                 # Set a sample history
                 sample_history = {
-                    "file_id_1": {
-                        "hash": "hash1",
-                        "path": "/path/to/document.odoc",
-                        "download_time": "2023-01-01 12:00:00"
+                    'file_id_1': {
+                        'hash': 'hash1',
+                        'path': '/path/to/document.odoc',
+                        'download_time': '2023-01-01 12:00:00'
                     }
                 }
                 exporter.download_history = sample_history
@@ -87,7 +87,7 @@ class TestSynologyOfficeExporter(unittest.TestCase):
                 exporter._save_download_history()
 
                 # Verify file was opened correctly
-                history_file = os.path.join(self.output_dir, ".download_history.json")
+                history_file = os.path.join(self.output_dir, '.download_history.json')
                 mock_file_open.assert_called_with(history_file, 'w')
 
                 # Verify history was dumped
@@ -98,16 +98,16 @@ class TestSynologyOfficeExporter(unittest.TestCase):
                     },
                     mock_file_open())
 
-    @patch("os.path.exists")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("json.load")
+    @patch('os.path.exists')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.load')
     def test_process_document_tracking(self, mock_json_load, mock_file_open, mock_path_exists):
         """Test that documents are properly tracked for deletion detection."""
         mock_path_exists.return_value = True
         mock_json_load.return_value = {}
 
         # Mock BytesIO for download
-        mock_data = BytesIO(b"test content")
+        mock_data = BytesIO(b'test content')
         self.mock_synd.download_synology_office_file.return_value = mock_data
 
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'):
@@ -117,10 +117,10 @@ class TestSynologyOfficeExporter(unittest.TestCase):
             exporter.current_file_paths = set()
 
             # Process a document - should add to current_file_paths
-            exporter._process_document("test_file_id", "/path/to/document.odoc", "hash123")
+            exporter._process_document('test_file_id', '/path/to/document.odoc', 'hash123')
 
             # Verify the file ID was added to the tracking set
-            self.assertIn("/path/to/document.odoc", exporter.current_file_paths)
+            self.assertIn('/path/to/document.odoc', exporter.current_file_paths)
 
     def test_stat_buf(self):
         """Test that statistics are correctly written to the provided buffer."""
@@ -135,19 +135,19 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         # Verify output matches expected format
         self.assertEqual(
             stat_buf.getvalue(),
-            "\n===== Download Results Summary =====\n\n"
-            "Total files found for backup: 3\n"
-            "Files skipped: 2\n"
-            "Files downloaded: 1\n"
-            "Files deleted: 4\n"
-            "=====================================\n"
+            '\n===== Download Results Summary =====\n\n'
+            'Total files found for backup: 3\n'
+            'Files skipped: 2\n'
+            'Files downloaded: 1\n'
+            'Files deleted: 4\n'
+            '=====================================\n'
         )
 
     def test_download_mydrive_files_with_exception(self):
         exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
 
         # Make list_folder raise an exception
-        self.mock_synd.list_folder.side_effect = Exception("Network error")
+        self.mock_synd.list_folder.side_effect = Exception('Network error')
 
         exporter.download_mydrive_files()
         self.assertTrue(exporter.had_exceptions)
@@ -156,7 +156,7 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
 
         # Make list_folder raise an exception
-        self.mock_synd.shared_with_me.side_effect = Exception("Network error")
+        self.mock_synd.shared_with_me.side_effect = Exception('Network error')
 
         exporter.download_shared_files()
         self.assertTrue(exporter.had_exceptions)
@@ -165,7 +165,7 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
 
         # Make list_folder raise an exception
-        self.mock_synd.get_teamfolder_info.side_effect = Exception("Network error")
+        self.mock_synd.get_teamfolder_info.side_effect = Exception('Network error')
 
         exporter.download_teamfolder_files()
         self.assertTrue(exporter.had_exceptions)
@@ -174,11 +174,11 @@ class TestSynologyOfficeExporter(unittest.TestCase):
         exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
 
         # Make download_synology_office_file raise an exception
-        self.mock_synd.download_synology_office_file.side_effect = Exception("Download error")
+        self.mock_synd.download_synology_office_file.side_effect = Exception('Download error')
 
-        exporter._process_document("testfile", "/path/to/test.odoc", "hash123")
+        exporter._process_document('testfile', '/path/to/test.odoc', 'hash123')
         self.assertTrue(exporter.had_exceptions)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_exporter_deleted_files.py
+++ b/tests/test_exporter_deleted_files.py
@@ -17,27 +17,27 @@ class TestOfficeFileRemoval(unittest.TestCase):
         """Set up test environment before each test."""
         self.mock_synd = MagicMock()
 
-        self.output_dir = "/tmp/synology_office_exports"
-        self.history_file = os.path.join(self.output_dir, ".download_history.json")
+        self.output_dir = '/tmp/synology_office_exports'
+        self.history_file = os.path.join(self.output_dir, '.download_history.json')
 
         self.sample_history = {
-            "/path/to/document.odoc": {
-                "file_id": "file_id_1",
-                "hash": "hash1",
-                "path": "/path/to/document.odoc",
-                "download_time": "2023-01-01 12:00:00"
+            '/path/to/document.odoc': {
+                'file_id': 'file_id_1',
+                'hash': 'hash1',
+                'path': '/path/to/document.odoc',
+                'download_time': '2023-01-01 12:00:00'
             },
-            "/path/to/spreadsheet.osheet": {
-                "file_id": "file_id_2",
-                "hash": "hash2",
-                "path": "/path/to/spreadsheet.osheet",
-                "download_time": "2023-01-01 12:00:00"
+            '/path/to/spreadsheet.osheet': {
+                'file_id': 'file_id_2',
+                'hash': 'hash2',
+                'path': '/path/to/spreadsheet.osheet',
+                'download_time': '2023-01-01 12:00:00'
             }
         }
 
-    @patch("os.path.exists")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("json.load")
+    @patch('os.path.exists')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.load')
     def test_load_download_history(self, mock_json_load, mock_file_open, mock_path_exists):
         """Test that download history is loaded correctly."""
         mock_path_exists.return_value = True
@@ -57,8 +57,8 @@ class TestOfficeFileRemoval(unittest.TestCase):
         mock_file_open.assert_called_once_with(self.history_file, 'r')
         self.assertEqual(exporter.download_history, self.sample_history)
 
-    @patch("os.path.exists")
-    @patch("os.remove")
+    @patch('os.path.exists')
+    @patch('os.remove')
     def test_remove_deleted_files(self, mock_remove, mock_path_exists):
         """Test that files deleted from NAS are removed from the output directory."""
         mock_path_exists.return_value = True
@@ -68,20 +68,20 @@ class TestOfficeFileRemoval(unittest.TestCase):
             exporter.download_history = self.sample_history.copy()
 
             # Simulate that one file still exists on NAS (document.odoc) and one is deleted (spreadsheet.osheet)
-            exporter.current_file_paths = {"/path/to/document.odoc"}
+            exporter.current_file_paths = {'/path/to/document.odoc'}
 
             # Call the method to test
             exporter._remove_deleted_files()
 
             # Check that the deleted file is removed from history
-            self.assertNotIn("/path/to/spreadsheet.osheet", exporter.download_history)
-            self.assertIn("/path/to/document.odoc", exporter.download_history)
+            self.assertNotIn('/path/to/spreadsheet.osheet', exporter.download_history)
+            self.assertIn('/path/to/document.odoc', exporter.download_history)
 
             # Check that the counter was incremented
             self.assertEqual(exporter.deleted_files, 1)
 
-    @patch("os.path.exists")
-    @patch("os.remove")
+    @patch('os.path.exists')
+    @patch('os.remove')
     def test_no_files_to_remove(self, mock_remove, mock_path_exists):
         """Test that no files are removed when all files still exist on NAS."""
         mock_path_exists.return_value = True
@@ -91,7 +91,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
             exporter.download_history = self.sample_history.copy()
 
             # Simulate that all files still exist on the NAS
-            exporter.current_file_paths = {"/path/to/document.odoc", "/path/to/spreadsheet.osheet"}
+            exporter.current_file_paths = {'/path/to/document.odoc', '/path/to/spreadsheet.osheet'}
 
             # Call the method to test
             exporter._remove_deleted_files()
@@ -105,8 +105,8 @@ class TestOfficeFileRemoval(unittest.TestCase):
             # Check that the counter wasn't incremented
             self.assertEqual(exporter.deleted_files, 0)
 
-    @patch("os.path.exists")
-    @patch("os.remove")
+    @patch('os.path.exists')
+    @patch('os.remove')
     def test_file_already_removed(self, mock_remove, mock_path_exists):
         """Test handling of files that are already removed from the filesystem."""
         # Mock file existence check to return False (file is already gone)
@@ -117,7 +117,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
             exporter.download_history = self.sample_history.copy()
 
             # Simulate that one file is deleted from NAS
-            exporter.current_file_paths = {"/path/to/document.odoc"}
+            exporter.current_file_paths = {'/path/to/document.odoc'}
 
             # Call the method to test
             exporter._remove_deleted_files()
@@ -126,15 +126,15 @@ class TestOfficeFileRemoval(unittest.TestCase):
             mock_remove.assert_not_called()
 
             # Check that the file is still removed from history
-            self.assertNotIn("/path/to/spreadsheet.osheet", exporter.download_history)
+            self.assertNotIn('/path/to/spreadsheet.osheet', exporter.download_history)
 
             # Check that the counter wasn't incremented (no actual deletion)
             self.assertEqual(exporter.deleted_files, 0)
 
-    @patch("os.makedirs")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("json.dump")
-    @patch("os.path.exists")
+    @patch('os.makedirs')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.dump')
+    @patch('os.path.exists')
     def test_save_updated_history(self, mock_path_exists, mock_json_dump, mock_file_open, mock_makedirs):
         """Test that updated history (after removal) is saved correctly."""
         mock_path_exists.return_value = True
@@ -149,7 +149,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
             with SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir) as exporter:
                 # Set partial history (as if spreadsheet.osheet has been deleted)
                 exporter.download_history = {
-                    "/path/to/document.odoc": self.sample_history["/path/to/document.odoc"]
+                    '/path/to/document.odoc': self.sample_history['/path/to/document.odoc']
                 }
                 # Json dump should be called when exiting the context manager
 
@@ -160,25 +160,25 @@ class TestOfficeFileRemoval(unittest.TestCase):
                                  '_meta': mock_get_metadata.return_value,
                                  'files': exporter.download_history
                              })
-            self.assertIn("/path/to/document.odoc", saved_data['files'])
-            self.assertNotIn("/path/to/spreadsheet.osheet", saved_data['files'])
+            self.assertIn('/path/to/document.odoc', saved_data['files'])
+            self.assertNotIn('/path/to/spreadsheet.osheet', saved_data['files'])
 
-    @patch("os.path.exists")
+    @patch('os.path.exists')
     def test_end_to_end_process(self, mock_path_exists):
         """Test the complete process of tracking and removing deleted files."""
         mock_path_exists.return_value = True
 
         # Mock SynologyDriveEx methods
         mock_list_resp = {
-            "success": True,
-            "data": {"items": [
-                {"file_id": "file_id_1", "name": "document.odoc",
-                    "display_path": "/path/to/document.odoc", "content_type": "document", "hash": "hash1"},
+            'success': True,
+            'data': {'items': [
+                {'file_id': 'file_id_1', 'name': 'document.odoc',
+                    'display_path': '/path/to/document.odoc', 'content_type': 'document', 'hash': 'hash1'},
                 # spreadsheet.osheet is missing, simulating it was deleted from NAS
             ]}
         }
         self.mock_synd.list_folder.return_value = mock_list_resp
-        self.mock_synd.download_synology_office_file.return_value = BytesIO(b"file content")
+        self.mock_synd.download_synology_office_file.return_value = BytesIO(b'file content')
 
         with patch.object(SynologyOfficeExporter, '_load_download_history'), \
                 patch.object(SynologyOfficeExporter, '_save_download_history'), \
@@ -189,17 +189,17 @@ class TestOfficeFileRemoval(unittest.TestCase):
             exporter.download_history = self.sample_history.copy()
 
             # Process directory which only has document.docx now
-            exporter._process_directory("dir_id", "test_dir")
+            exporter._process_directory('dir_id', 'test_dir')
 
             # Exit to trigger the removal of deleted files
             exporter.__exit__(None, None, None)
 
             # Verify spreadsheet.xlsx was removed
             mock_remove.assert_called_once_with(
-                os.path.join(self.output_dir, "path/to/spreadsheet.xlsx"))
+                os.path.join(self.output_dir, 'path/to/spreadsheet.xlsx'))
 
             # Check history was updated
-            self.assertNotIn("/path/to/spreadsheet.osheet", exporter.download_history)
+            self.assertNotIn('/path/to/spreadsheet.osheet', exporter.download_history)
 
             # Check counters
             self.assertEqual(exporter.deleted_files, 1)
@@ -216,7 +216,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
         exporter.current_file_paths = set()
 
         # Make first deletion raise an exception
-        mock_remove.side_effect = Exception("Permission denied")
+        mock_remove.side_effect = Exception('Permission denied')
 
         # Run the method
         exporter._remove_deleted_files()
@@ -224,7 +224,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
         # Verify exception flag was set
         self.assertTrue(exporter.had_exceptions)
 
-    @patch("os.path.exists")
+    @patch('os.path.exists')
     @patch('os.remove')
     def test_file_deletion_in_context_manager(self, mock_remove, mock_path_exists):
         mock_path_exists.return_value = True
@@ -233,7 +233,7 @@ class TestOfficeFileRemoval(unittest.TestCase):
         exporter.download_history = self.sample_history.copy()
 
         # Mark document.docx as deleted (not in current_file_paths)
-        exporter.current_file_paths = {"/path/to/spreadsheet.osheet"}
+        exporter.current_file_paths = {'/path/to/spreadsheet.osheet'}
 
         # Ensure no exceptions
         exporter.had_exceptions = False
@@ -257,11 +257,11 @@ class TestOfficeFileRemoval(unittest.TestCase):
         exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
         # Simulate an exception during processing, and not captured.
         exporter.had_exceptions = False
-        exporter.__exit__(ValueError, ValueError("Test exception"), None)
+        exporter.__exit__(ValueError, ValueError('Test exception'), None)
 
         # Verify no files were deleted
         mock_remove.assert_not_called()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_exporter_download.py
+++ b/tests/test_exporter_download.py
@@ -155,7 +155,7 @@ class TestDownload(unittest.TestCase):
         # Make the second file raise an exception when processed
         def side_effect(item):
             if item['file_id'] == '456':
-                raise Exception("Test error")
+                raise Exception('Test error')
             return None
         mock_process_item.side_effect = side_effect
 
@@ -174,7 +174,7 @@ class TestDownload(unittest.TestCase):
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
     def test_exception_handling_mydrive(self, mock_process_directory):
         """Test that exceptions in _process_directory do not stop execution."""
-        mock_process_directory.side_effect = Exception("Test error")
+        mock_process_directory.side_effect = Exception('Test error')
 
         exporter = SynologyOfficeExporter(self.mock_synd, skip_history=True)
         exporter.download_mydrive_files()
@@ -194,7 +194,7 @@ class TestDownload(unittest.TestCase):
         # Make processing of 'Team Folder 2' raise an exception
         def side_effect(file_id, name):
             if file_id == '222':
-                raise Exception("Test error")
+                raise Exception('Test error')
             return None
         mock_process_directory.side_effect = side_effect
 
@@ -211,7 +211,7 @@ class TestDownload(unittest.TestCase):
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
     def test_exception_handling_download_synology(self, mock_save, mock_download):
         """Test that exceptions during file download do not stop processing."""
-        mock_download.side_effect = Exception("Download failed")
+        mock_download.side_effect = Exception('Download failed')
         self.mock_synd.download_synology_office_file = mock_download
 
         exporter = SynologyOfficeExporter(self.mock_synd, skip_history=True)
@@ -223,7 +223,7 @@ class TestDownload(unittest.TestCase):
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
     def test_exception_handling_download(self, mock_save):
         """Test that exceptions during file download do not stop processing."""
-        self.mock_synd.download_synology_office_file.side_effect = Exception("Download failed")
+        self.mock_synd.download_synology_office_file.side_effect = Exception('Download failed')
 
         exporter = SynologyOfficeExporter(self.mock_synd, skip_history=True)
         exporter._process_document('123', 'path/to/test.osheet', hash=None)
@@ -404,7 +404,7 @@ class TestDownload(unittest.TestCase):
         """Test that an error is raised when the download history file is corrupt."""
         mock_exists.return_value = True
         # Simulate an error caused by invalid JSON
-        mock_json_load.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        mock_json_load.side_effect = json.JSONDecodeError('Invalid JSON', '', 0)
 
         from synology_office_exporter.exception import DownloadHistoryError
         with self.assertRaises(DownloadHistoryError):


### PR DESCRIPTION
Replace double quotes with single quotes in Python source files to follow
the project style guide as defined in .flake8:
- inline-quotes = single
- multiline-quotes = single
- docstring-quotes = double

Also fix a logging level in exporter.py from debug to warning for better clarity
when files are already removed on the filesystem.

This change is purely stylistic and doesn't affect functionality.