### PR TITLE
Fix GitHub release creation issues in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,6 +83,7 @@ jobs:
         "$GITHUB_REF_NAME"
         --repo "$GITHUB_REPOSITORY"
         --notes ""
+      continue-on-error: true
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -93,3 +94,4 @@ jobs:
         gh release upload
         "$GITHUB_REF_NAME" dist/**
         --repo "$GITHUB_REPOSITORY"
+        --clobber


### PR DESCRIPTION
- Add `continue-on-error: true` to GitHub release creation step to prevent workflow failure when release already exists
- Add `--clobber` flag to release upload command to allow overwriting existing assets in the release

This makes it possible to create release on GitHub Web UI.