### PR TITLE
Refactor tests for download history into separate class

### DIFF
--- a/synology_office_exporter/exporter.py
+++ b/synology_office_exporter/exporter.py
@@ -74,10 +74,7 @@ class SynologyOfficeExporter:
 
         # Initialize history storage
         if download_history_storage is None:
-            self.__history_storage = DownloadHistoryFile(
-                output_dir=output_dir,
-                force_download=force_download
-            )
+            raise Exception('Download history storage is required')
         else:
             self.__history_storage = download_history_storage
 

--- a/synology_office_exporter/exporter.py
+++ b/synology_office_exporter/exporter.py
@@ -57,13 +57,14 @@ class SynologyOfficeExporter:
             exporter.download_shared_files()
     """
 
-    def __init__(self, synd: SynologyDriveEx, output_dir: str = '.', force_download: bool = False,
-                 stat_buf: StringIO = None, download_history_storage: DownloadHistoryFile = None):
+    def __init__(self, synd: SynologyDriveEx, download_history_storage: DownloadHistoryFile,
+                 output_dir: str = '.', force_download: bool = False, stat_buf: StringIO = None):
         """
         Initialize the SynologyOfficeExporter with the given parameters.
 
         Args:
             synd: SynologyDriveEx instance for API communication
+            download_history_storage: DownloadHistoryFile instance for tracking download history
             output_dir: Directory where converted files will be saved
             force_download: If True, files will be downloaded regardless of download history
             stat_buf: StringIO buffer to write statistics output
@@ -73,10 +74,7 @@ class SynologyOfficeExporter:
         self.stat_buf = stat_buf
 
         # Initialize history storage
-        if download_history_storage is None:
-            raise Exception('Download history storage is required')
-        else:
-            self.__history_storage = download_history_storage
+        self.__history_storage = download_history_storage
 
         # Counters for tracking statistics
         self.total_found_files = 0

--- a/tests/test_deleted_files.py
+++ b/tests/test_deleted_files.py
@@ -181,7 +181,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('os.remove')
     def test_no_file_deletion_when_exception_occurs_and_captured(self, mock_remove):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports')
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
+                                          download_history_storage=MagicMock())
         # Simulate an exception during processing, captured by except block which sets had_exceptions.
         exporter.had_exceptions = True
         exporter.__exit__(None, None, None)
@@ -191,7 +192,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('os.remove')
     def test_no_file_deletion_when_exception_occurs_and_not_captured(self, mock_remove):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports')
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
+                                          download_history_storage=MagicMock())
         # Simulate an exception during processing, and not captured.
         exporter.had_exceptions = False
         exporter.__exit__(ValueError, ValueError('Test exception'), None)

--- a/tests/test_deleted_files.py
+++ b/tests/test_deleted_files.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from synology_office_exporter.exporter import SynologyOfficeExporter
+from tests.mock_download_history import MockDownloadHistory
 
 
 class TestDeletedFiles(unittest.TestCase):
@@ -37,8 +38,8 @@ class TestDeletedFiles(unittest.TestCase):
         mock_path_exists.return_value = True
 
         download_history = MagicMock()
-        with SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                    download_history_storage=download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, download_history,
+                                    output_dir='/tmp/synology_office_exports') as exporter:
             # Simliate that the history file is loaded, and there were two files when the exporter was executed
             # last time.
             download_history.get_history_keys.return_value = set(
@@ -58,8 +59,7 @@ class TestDeletedFiles(unittest.TestCase):
     def test_file_already_removed(self, mock_remove):
         """Test handling of files that are already removed from the filesystem."""
         download_history = MagicMock()
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=download_history)
+        exporter = SynologyOfficeExporter(self.mock_synd, download_history, output_dir='/tmp/synology_office_exports')
         # Simliate that the history file is loaded, and there were two files when the exporter was executed
         # last time.
         download_history.get_history_keys.return_value = set(
@@ -91,8 +91,8 @@ class TestDeletedFiles(unittest.TestCase):
         download_history = MagicMock()
         download_history.get_history_keys.return_value = set(
             ['/path/to/document.odoc', '/path/to/spreadsheet.osheet'])
-        with SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                    download_history_storage=download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, download_history,
+                                    output_dir='/tmp/synology_office_exports') as exporter:
             # Simulate that all files still exist on the NAS
             exporter.current_file_paths = {'/path/to/document.odoc', '/path/to/spreadsheet.osheet'}
 
@@ -111,8 +111,7 @@ class TestDeletedFiles(unittest.TestCase):
         download_history = MagicMock()
         download_history.get_history_keys.return_value = set(['/path/to/document.odoc'])
 
-        with SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                    download_history_storage=download_history):
+        with SynologyOfficeExporter(self.mock_synd, download_history, output_dir='/tmp/synology_office_exports'):
             pass
 
         # Verify that the deleted file from the NAS device is removed locally, and history is updated.
@@ -125,7 +124,7 @@ class TestDeletedFiles(unittest.TestCase):
         download_history = MagicMock()
 
         exporter = SynologyOfficeExporter(
-            self.mock_synd, output_dir='/tmp/synology_office_exports', download_history_storage=download_history)
+            self.mock_synd, download_history, output_dir='/tmp/synology_office_exports')
 
         # Simliate that the history file is loaded, and there were two files when the exporter was executed
         # last time.
@@ -148,8 +147,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._remove_deleted_files')
     def test_file_deletion_in_context_manager(self, mock_remove_deleted_files):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
         # Ensure no exceptions
         exporter.had_exceptions = False
         exporter.__exit__(None, None, None)
@@ -159,8 +158,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._remove_deleted_files')
     def test_no_file_deletion_in_context_manager_with_exceptions_handled(self, mock_remove_deleted_files):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
         # Simulate exceptions occured but captured
         exporter.had_exceptions = True
         exporter.__exit__(None, None, None)
@@ -170,8 +169,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._remove_deleted_files')
     def test_no_file_deletion_in_context_manager_with_exceptions_not_handled(self, mock_remove_deleted_files):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
         # Simulate exceptions occured and not captured
         exporter.had_exceptions = False
         exporter.__exit__(Exception, None, None)
@@ -181,8 +180,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('os.remove')
     def test_no_file_deletion_when_exception_occurs_and_captured(self, mock_remove):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
         # Simulate an exception during processing, captured by except block which sets had_exceptions.
         exporter.had_exceptions = True
         exporter.__exit__(None, None, None)
@@ -192,8 +191,8 @@ class TestDeletedFiles(unittest.TestCase):
 
     @patch('os.remove')
     def test_no_file_deletion_when_exception_occurs_and_not_captured(self, mock_remove):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
         # Simulate an exception during processing, and not captured.
         exporter.had_exceptions = False
         exporter.__exit__(ValueError, ValueError('Test exception'), None)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -35,7 +35,7 @@ class TestDownload(unittest.TestCase):
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
 
         # Create SynologyOfficeExporter instance with test output directory
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter.save_bytesio_to_file = mock_save_bytesio_to_file
         exporter._process_document('123', 'path/to/test.osheet', hash=None)
 
@@ -62,7 +62,7 @@ class TestDownload(unittest.TestCase):
             {'file_id': '456', 'content_type': 'dir', 'name': 'folder1'}
         ]
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter.download_shared_files()
 
         # Verify _process_item was called for each shared item
@@ -79,7 +79,7 @@ class TestDownload(unittest.TestCase):
             'Team Folder 2': '012'
         }
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter.download_teamfolder_files()
 
         # Verify _process_directory was called for each team folder
@@ -92,7 +92,7 @@ class TestDownload(unittest.TestCase):
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_document')
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
     def test_process_item(self, mock_process_directory, mock_process_document):
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
 
         # Test directory item
         dir_item = {
@@ -137,7 +137,7 @@ class TestDownload(unittest.TestCase):
 
     @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
     def test_download_mydrive_files(self, mock_process_directory):
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
 
         exporter.download_mydrive_files()
         mock_process_directory.assert_called_once_with('/mydrive', 'My Drive')
@@ -160,7 +160,7 @@ class TestDownload(unittest.TestCase):
         mock_process_item.side_effect = side_effect
 
         # Create exporter instance
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
 
         # Call method to test
         exporter.download_shared_files()
@@ -176,7 +176,7 @@ class TestDownload(unittest.TestCase):
         """Test that exceptions in _process_directory do not stop execution."""
         mock_process_directory.side_effect = Exception('Test error')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter.download_mydrive_files()
 
         # Verify _process_directory was called with correct parameters
@@ -198,7 +198,7 @@ class TestDownload(unittest.TestCase):
             return None
         mock_process_directory.side_effect = side_effect
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter.download_teamfolder_files()
 
         # Verify all team folders were attempted to be processed
@@ -214,7 +214,7 @@ class TestDownload(unittest.TestCase):
         mock_download.side_effect = Exception('Download failed')
         self.mock_synd.download_synology_office_file = mock_download
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter._process_document('123', 'path/to/test.osheet', hash=None)
 
         mock_download.assert_called_once_with('123')
@@ -225,7 +225,7 @@ class TestDownload(unittest.TestCase):
         """Test that exceptions during file download do not stop processing."""
         self.mock_synd.download_synology_office_file.side_effect = Exception('Download failed')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
         exporter._process_document('123', 'path/to/test.osheet', hash=None)
 
         # Verify download was attempted
@@ -241,8 +241,7 @@ class TestDownload(unittest.TestCase):
         download_history = MagicMock()
         download_history.should_download.return_value = False
 
-        with SynologyOfficeExporter(self.mock_synd,
-                                    download_history_storage=download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, download_history) as exporter:
             exporter._process_document('123', 'path/to/test.osheet', 'old-hash')
 
         # Verify that download was not attempted
@@ -254,7 +253,7 @@ class TestDownload(unittest.TestCase):
         """Test that new files are added to download history."""
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'new file data')
         download_history = MagicMock()
-        with SynologyOfficeExporter(self.mock_synd, download_history_storage=download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, download_history) as exporter:
             exporter._process_document('456', 'path/to/new.osheet', 'new-file-hash')
 
         # Verify that download was attempted
@@ -270,8 +269,7 @@ class TestDownload(unittest.TestCase):
         download_history = MockDownloadHistory()
 
         # Use the custom history storage with the exporter
-        with SynologyOfficeExporter(self.mock_synd, output_dir='/test/dir',
-                                    download_history_storage=download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, download_history, output_dir='/test/dir',) as exporter:
             # Verify that the exporter is using our custom history storage
 
             # Verify that lock and load methods were called during initialization
@@ -299,8 +297,7 @@ class TestDownload(unittest.TestCase):
     def test_context_manager(self, mock_process):
         """Test that context manager loads and saves download history."""
         mock_download_history = MockDownloadHistory()
-        with SynologyOfficeExporter(self.mock_synd, output_dir='/test/dir',
-                                    download_history_storage=mock_download_history) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, mock_download_history, output_dir='/test/dir') as exporter:
             # In the context, lock and load should have been called already
             self.assertTrue(mock_download_history.lock_called)
             self.assertTrue(mock_download_history.load_called)
@@ -321,8 +318,7 @@ class TestDownload(unittest.TestCase):
         """Test that force_download option downloads files regardless of history."""
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='.',
-                                          force_download=True, download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir='.', force_download=True)
         exporter.download_history = {
             'path/to/test.osheet': {
                 'file_id': '123',

--- a/tests/test_download_history.py
+++ b/tests/test_download_history.py
@@ -142,10 +142,9 @@ class TestDownloadHistory(unittest.TestCase):
             'files': {}
         }
 
-        download_history_storage = DownloadHistoryFile(self.output_dir, skip_lock=True)
-
+        download_history = DownloadHistoryFile(self.output_dir, skip_lock=True)
         with self.assertRaises(DownloadHistoryError):
-            download_history_storage.load_history()
+            download_history.load_history()
 
         # Verify that the history file was attempted to be opened
         mock_exists.assert_called_once_with(os.path.join(self.output_dir, '.download_history.json'))
@@ -170,9 +169,9 @@ class TestDownloadHistory(unittest.TestCase):
             'files': {}
         }
 
-        downald_history_storage = DownloadHistoryFile(self.output_dir, skip_lock=True)
+        download_history = DownloadHistoryFile(self.output_dir, skip_lock=True)
         with self.assertRaises(DownloadHistoryError):
-            downald_history_storage.load_history()
+            download_history.load_history()
 
         # Verify that the history file was attempted to be opened
         mock_exists.assert_called_once_with(os.path.join(self.output_dir, '.download_history.json'))

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -71,8 +71,8 @@ class TestExporter(unittest.TestCase):
         self.mock_synd.download_synology_office_file.return_value = mock_data
 
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'):
-            exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
-                                              download_history_storage=MagicMock())
+            exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
+                                              stat_buf=None)
 
             # Clear any auto-loaded history
             exporter.current_file_paths = set()
@@ -87,8 +87,8 @@ class TestExporter(unittest.TestCase):
         """Test that statistics are correctly written to the provided buffer."""
         stat_buf = StringIO()
 
-        with SynologyOfficeExporter(self.mock_synd, stat_buf=stat_buf,
-                                    download_history_storage=MagicMock()) as exporter:
+        with SynologyOfficeExporter(self.mock_synd, MagicMock(), stat_buf=stat_buf,
+                                    output_dir=self.output_dir) as exporter:
             exporter.total_found_files = 3
             exporter.skipped_files = 2
             exporter.downloaded_files = 1
@@ -106,8 +106,8 @@ class TestExporter(unittest.TestCase):
         )
 
     def test_download_mydrive_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
+                                          stat_buf=None)
 
         # Make list_folder raise an exception
         self.mock_synd.list_folder.side_effect = Exception('Network error')
@@ -116,8 +116,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_shared_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
+                                          stat_buf=None)
 
         # Make list_folder raise an exception
         self.mock_synd.shared_with_me.side_effect = Exception('Network error')
@@ -126,8 +126,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_teamfolder_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
+                                          stat_buf=None)
 
         # Make list_folder raise an exception
         self.mock_synd.get_teamfolder_info.side_effect = Exception('Network error')
@@ -136,8 +136,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_process_document_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
+                                          stat_buf=None)
 
         # Make download_synology_office_file raise an exception
         self.mock_synd.download_synology_office_file.side_effect = Exception('Download error')
@@ -163,8 +163,8 @@ class TestExporter(unittest.TestCase):
         }
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'file content')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir='/tmp/synology_office_exports',
-                                          download_history_storage=MagicMock())
+        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir='/tmp/synology_office_exports',
+                                          stat_buf=None)
 
         # Process directory which only has document.docx now
         exporter._process_directory('dir_id', 'test_dir')

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -8,6 +8,7 @@ from io import BytesIO, StringIO
 import os
 
 from synology_office_exporter.exporter import SynologyOfficeExporter
+from tests.mock_download_history import MockDownloadHistory
 
 
 class TestExporter(unittest.TestCase):
@@ -71,8 +72,7 @@ class TestExporter(unittest.TestCase):
         self.mock_synd.download_synology_office_file.return_value = mock_data
 
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'):
-            exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
-                                              stat_buf=None)
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
 
             # Clear any auto-loaded history
             exporter.current_file_paths = set()
@@ -87,7 +87,7 @@ class TestExporter(unittest.TestCase):
         """Test that statistics are correctly written to the provided buffer."""
         stat_buf = StringIO()
 
-        with SynologyOfficeExporter(self.mock_synd, MagicMock(), stat_buf=stat_buf,
+        with SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), stat_buf=stat_buf,
                                     output_dir=self.output_dir) as exporter:
             exporter.total_found_files = 3
             exporter.skipped_files = 2
@@ -106,8 +106,7 @@ class TestExporter(unittest.TestCase):
         )
 
     def test_download_mydrive_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
-                                          stat_buf=None)
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
 
         # Make list_folder raise an exception
         self.mock_synd.list_folder.side_effect = Exception('Network error')
@@ -116,8 +115,7 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_shared_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
-                                          stat_buf=None)
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
 
         # Make list_folder raise an exception
         self.mock_synd.shared_with_me.side_effect = Exception('Network error')
@@ -126,8 +124,7 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_teamfolder_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
-                                          stat_buf=None)
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
 
         # Make list_folder raise an exception
         self.mock_synd.get_teamfolder_info.side_effect = Exception('Network error')
@@ -136,8 +133,7 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_process_document_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir=self.output_dir,
-                                          stat_buf=None)
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
 
         # Make download_synology_office_file raise an exception
         self.mock_synd.download_synology_office_file.side_effect = Exception('Download error')
@@ -163,8 +159,8 @@ class TestExporter(unittest.TestCase):
         }
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'file content')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, MagicMock(), output_dir='/tmp/synology_office_exports',
-                                          stat_buf=None)
+        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
+                                          output_dir='/tmp/synology_office_exports')
 
         # Process directory which only has document.docx now
         exporter._process_directory('dir_id', 'test_dir')

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -71,7 +71,8 @@ class TestExporter(unittest.TestCase):
         self.mock_synd.download_synology_office_file.return_value = mock_data
 
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'):
-            exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
+            exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
+                                              download_history_storage=MagicMock())
 
             # Clear any auto-loaded history
             exporter.current_file_paths = set()
@@ -105,7 +106,8 @@ class TestExporter(unittest.TestCase):
         )
 
     def test_download_mydrive_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
+                                          download_history_storage=MagicMock())
 
         # Make list_folder raise an exception
         self.mock_synd.list_folder.side_effect = Exception('Network error')
@@ -114,7 +116,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_shared_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
+                                          download_history_storage=MagicMock())
 
         # Make list_folder raise an exception
         self.mock_synd.shared_with_me.side_effect = Exception('Network error')
@@ -123,7 +126,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_teamfolder_files_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
+                                          download_history_storage=MagicMock())
 
         # Make list_folder raise an exception
         self.mock_synd.get_teamfolder_info.side_effect = Exception('Network error')
@@ -132,7 +136,8 @@ class TestExporter(unittest.TestCase):
         self.assertTrue(exporter.had_exceptions)
 
     def test_process_document_with_exception(self):
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir)
+        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.output_dir,
+                                          download_history_storage=MagicMock())
 
         # Make download_synology_office_file raise an exception
         self.mock_synd.download_synology_office_file.side_effect = Exception('Download error')

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -85,18 +85,18 @@ class TestFileLockIntegration(unittest.TestCase):
     def test_concurrent_access_prevention(self, mock_load):
         """Test that a second instance cannot acquire the lock when first one holds it."""
         # First instance
-        download_history_storage = DownloadHistoryFile(output_dir=self.temp_dir.name)
-        with SynologyOfficeExporter(self.synd_mock, download_history_storage, output_dir=self.temp_dir.name):
+        download_history = DownloadHistoryFile(output_dir=self.temp_dir.name)
+        with SynologyOfficeExporter(self.synd_mock, download_history, output_dir=self.temp_dir.name):
 
             # Try to create a second instance that should fail
-            download_history_storage2 = DownloadHistoryFile(output_dir=self.temp_dir.name)
+            download_history2 = DownloadHistoryFile(output_dir=self.temp_dir.name)
             with self.assertRaises(DownloadHistoryError):
-                with SynologyOfficeExporter(self.synd_mock, download_history_storage2, output_dir=self.temp_dir.name):
+                with SynologyOfficeExporter(self.synd_mock, download_history2, output_dir=self.temp_dir.name):
                     self.fail()  # Should not reach here
 
         # Verify lock file is released by creating a new instance after cleanup
-        download_history_storage3 = DownloadHistoryFile(output_dir=self.temp_dir.name)
-        with SynologyOfficeExporter(self.synd_mock, download_history_storage3, output_dir=self.temp_dir.name):
+        download_history3 = DownloadHistoryFile(output_dir=self.temp_dir.name)
+        with SynologyOfficeExporter(self.synd_mock, download_history3, output_dir=self.temp_dir.name):
             # If we get here, it means the lock was successfully acquired
             pass
 

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -86,20 +86,17 @@ class TestFileLockIntegration(unittest.TestCase):
         """Test that a second instance cannot acquire the lock when first one holds it."""
         # First instance
         download_history_storage = DownloadHistoryFile(output_dir=self.temp_dir.name)
-        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
-                                    download_history_storage=download_history_storage):
+        with SynologyOfficeExporter(self.synd_mock, download_history_storage, output_dir=self.temp_dir.name):
 
             # Try to create a second instance that should fail
             download_history_storage2 = DownloadHistoryFile(output_dir=self.temp_dir.name)
             with self.assertRaises(DownloadHistoryError):
-                with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
-                                            download_history_storage=download_history_storage2):
+                with SynologyOfficeExporter(self.synd_mock, download_history_storage2, output_dir=self.temp_dir.name):
                     self.fail()  # Should not reach here
 
         # Verify lock file is released by creating a new instance after cleanup
         download_history_storage3 = DownloadHistoryFile(output_dir=self.temp_dir.name)
-        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
-                                    download_history_storage=download_history_storage3):
+        with SynologyOfficeExporter(self.synd_mock, download_history_storage3, output_dir=self.temp_dir.name):
             # If we get here, it means the lock was successfully acquired
             pass
 

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -85,16 +85,23 @@ class TestFileLockIntegration(unittest.TestCase):
     def test_concurrent_access_prevention(self, mock_load):
         """Test that a second instance cannot acquire the lock when first one holds it."""
         # First instance
-        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name):
+        download_history_storage = DownloadHistoryFile(output_dir=self.temp_dir.name)
+        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
+                                    download_history_storage=download_history_storage):
+
             # Try to create a second instance that should fail
+            download_history_storage2 = DownloadHistoryFile(output_dir=self.temp_dir.name)
             with self.assertRaises(DownloadHistoryError):
-                with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name):
-                    self.assertTrue(False)  # Should not reach here
+                with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
+                                            download_history_storage=download_history_storage2):
+                    self.fail()  # Should not reach here
 
         # Verify lock file is released by creating a new instance after cleanup
-        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name):
+        download_history_storage3 = DownloadHistoryFile(output_dir=self.temp_dir.name)
+        with SynologyOfficeExporter(self.synd_mock, output_dir=self.temp_dir.name,
+                                    download_history_storage=download_history_storage3):
             # If we get here, it means the lock was successfully acquired
-            self.assertTrue(True)
+            pass
 
 
 if __name__ == '__main__':

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -19,7 +19,8 @@ class TestStats(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
 
         # Create an instance of the exporter
-        self.exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.temp_dir)
+        self.exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.temp_dir,
+                                               download_history_storage=MagicMock())
 
         # Reset statistics counters
         self.exporter.total_found_files = 0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,6 +6,7 @@ import tempfile
 from io import BytesIO
 
 from synology_office_exporter.exporter import SynologyOfficeExporter
+from tests.mock_download_history import MockDownloadHistory
 
 
 class TestStats(unittest.TestCase):
@@ -19,8 +20,7 @@ class TestStats(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
 
         # Create an instance of the exporter
-        self.exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.temp_dir,
-                                               download_history_storage=MagicMock())
+        self.exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.temp_dir)
 
         # Reset statistics counters
         self.exporter.total_found_files = 0
@@ -62,10 +62,10 @@ class TestStats(unittest.TestCase):
         display_path = 'test_document.odoc'
         file_hash = 'test_hash'
 
+        # Simulate that the file is already downloaded
         download_history_storage = MagicMock()
         download_history_storage.should_download.return_value = False
-        exporter = SynologyOfficeExporter(self.mock_synd, output_dir=self.temp_dir,
-                                          download_history_storage=download_history_storage)
+        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage, output_dir=self.temp_dir)
 
         # Execute the test
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -63,9 +63,9 @@ class TestStats(unittest.TestCase):
         file_hash = 'test_hash'
 
         # Simulate that the file is already downloaded
-        download_history_storage = MagicMock()
-        download_history_storage.should_download.return_value = False
-        exporter = SynologyOfficeExporter(self.mock_synd, download_history_storage, output_dir=self.temp_dir)
+        download_history = MagicMock()
+        download_history.should_download.return_value = False
+        exporter = SynologyOfficeExporter(self.mock_synd, download_history, output_dir=self.temp_dir)
 
         # Execute the test
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save:


### PR DESCRIPTION
fix #19

- Modified SynologyOfficeExporter to accept a download_history_storage parameter instead of creating the history object internally
- Updated tests to use the new class structure with proper dependency injection
- Moved download history tests from test_download.py to test_download_history.py
- Fixed file lock tests to work with the refactored code
- Ensured all tests properly mock the download history storage when needed

This change provides better testability and allows for alternative implementations of history storage in the future.