### PR TITLE
Refactor/refine tests

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,7 +2,6 @@
 import unittest
 from unittest.mock import patch, MagicMock, call
 from io import BytesIO
-import os
 from synology_office_exporter.exporter import SynologyOfficeExporter
 from synology_office_exporter.synology_drive_api import SynologyDriveEx
 from tests.mock_download_history import MockDownloadHistory
@@ -14,8 +13,8 @@ class TestDownload(unittest.TestCase):
     def setUp(self):
         self.mock_synd = MagicMock(spec=SynologyDriveEx)
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_process_document(self, mock_save_bytesio_to_file):
+    def test_process_document(self):
+        """Test processing a document file."""
         self.mock_synd.list_folder.return_value = {
             'success': True,
             'data': {
@@ -34,20 +33,20 @@ class TestDownload(unittest.TestCase):
         }
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
 
-        # Create SynologyOfficeExporter instance with test output directory
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter.save_bytesio_to_file = mock_save_bytesio_to_file
-        exporter._process_document('123', 'path/to/test.osheet', hash=None)
-
-        # Check if save_bytesio_to_file was called with correct parameters
-        args, kwargs = mock_save_bytesio_to_file.call_args
-        self.assertEqual(args[0].getvalue(), b'test data')
-        self.assertEqual(os.path.basename(args[1]), 'test.xlsx')
+        with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir='/test/dir')
+            exporter._process_document('123', 'path/to/test.osheet', hash=None)
 
         # Check if download_synology_office_file was called correctly
         self.mock_synd.download_synology_office_file.assert_called_once_with('123')
 
+        # Check if save_bytesio_to_file was called with correct parameters
+        args, kwargs = mock_save.call_args
+        self.assertEqual(args[0].getvalue(), b'test data')
+        self.assertEqual(args[1], '/test/dir/path/to/test.xlsx')
+
     def test_convert_synology_to_ms_office_filename(self):
+        """Test conversion of Synology Office filenames to MS Office filenames."""
         # For Synology Office files, convert to MS Office extensions
         self.assertEqual(SynologyOfficeExporter.convert_synology_to_ms_office_filename('test.osheet'), 'test.xlsx')
         self.assertEqual(SynologyOfficeExporter.convert_synology_to_ms_office_filename('test.odoc'), 'test.docx')
@@ -55,15 +54,16 @@ class TestDownload(unittest.TestCase):
         # For other files, return None
         self.assertIsNone(SynologyOfficeExporter.convert_synology_to_ms_office_filename('test.txt'))
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_item')
-    def test_download_shared_files(self, mock_process_item):
+    def test_download_shared_files(self):
+        """Test downloading files shared with the user."""
         self.mock_synd.shared_with_me.return_value = [
             {'file_id': '123', 'content_type': 'document', 'name': 'doc1'},
             {'file_id': '456', 'content_type': 'dir', 'name': 'folder1'}
         ]
 
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter.download_shared_files()
+        with patch.object(SynologyOfficeExporter, '_process_item') as mock_process_item:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter.download_shared_files()
 
         # Verify _process_item was called for each shared item
         self.assertEqual(mock_process_item.call_count, 2)
@@ -72,15 +72,16 @@ class TestDownload(unittest.TestCase):
             call({'file_id': '456', 'content_type': 'dir', 'name': 'folder1'})
         ])
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
-    def test_download_teamfolder_files(self, mock_process_directory):
+    def test_download_teamfolder_files(self):
+        """Test downloading files from team folders."""
         self.mock_synd.get_teamfolder_info.return_value = {
             'Team Folder 1': '789',
             'Team Folder 2': '012'
         }
 
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter.download_teamfolder_files()
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter.download_teamfolder_files()
 
         # Verify _process_directory was called for each team folder
         self.assertEqual(mock_process_directory.call_count, 2)
@@ -89,49 +90,53 @@ class TestDownload(unittest.TestCase):
             call('012', 'Team Folder 2')
         ], any_order=True)  # Order of dictionary items is not guaranteed
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_document')
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
-    def test_process_item(self, mock_process_directory, mock_process_document):
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-
-        # Test directory item
-        dir_item = {
+    def test_process_item_dir(self):
+        """Test processing a directory item."""
+        item = {
             'file_id': '456',
             'content_type': 'dir',
             'display_path': 'path/to/folder'
         }
-        exporter._process_item(dir_item)
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory, \
+                patch.object(SynologyOfficeExporter, '_process_document') as mock_process_document:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter._process_item(item)
+
         mock_process_directory.assert_called_once_with('456', 'path/to/folder')
         mock_process_document.assert_not_called()
 
-        # Reset mocks
-        mock_process_directory.reset_mock()
-        mock_process_document.reset_mock()
-
-        # Test document item
-        doc_item = {
+    def test_process_item_doc(self):
+        """Test processing a non-encrypted document item."""
+        item = {
             'file_id': '123',
             'content_type': 'document',
             'display_path': 'path/to/doc.osheet',
             'encrypted': False
         }
-        exporter._process_item(doc_item)
+
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory, \
+                patch.object(SynologyOfficeExporter, '_process_document') as mock_process_document:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter._process_item(item)
+
         # Modify this line to check with positional arguments instead of keyword arguments
         mock_process_document.assert_called_once_with('123', 'path/to/doc.osheet', None)
         mock_process_directory.assert_not_called()
 
-        # Reset mocks
-        mock_process_directory.reset_mock()
-        mock_process_document.reset_mock()
-
-        # Test encrypted document item
-        encrypted_doc = {
+    def test_process_item_encrypted_doc(self):
+        """Test processing an encrypted document item."""
+        item = {
             'file_id': '789',
             'content_type': 'document',
             'display_path': 'path/to/secret.osheet',
             'encrypted': True
         }
-        exporter._process_item(encrypted_doc)
+
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory, \
+                patch.object(SynologyOfficeExporter, '_process_document') as mock_process_document:
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter._process_item(item)
+
         mock_process_document.assert_not_called()
         mock_process_directory.assert_not_called()
 
@@ -142,8 +147,7 @@ class TestDownload(unittest.TestCase):
         exporter.download_mydrive_files()
         mock_process_directory.assert_called_once_with('/mydrive', 'My Drive')
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_item')
-    def test_exception_handling_shared_files(self, mock_process_item):
+    def test_exception_handling_shared_files(self):
         """Test that the program continues downloading even if some files cause exceptions."""
         # Set up mock to have 3 files, with processing of the second one raising an exception
         self.mock_synd.shared_with_me.return_value = [
@@ -152,18 +156,15 @@ class TestDownload(unittest.TestCase):
             {'file_id': '789', 'content_type': 'document', 'name': 'doc2'}
         ]
 
-        # Make the second file raise an exception when processed
-        def side_effect(item):
-            if item['file_id'] == '456':
-                raise Exception('Test error')
-            return None
-        mock_process_item.side_effect = side_effect
-
-        # Create exporter instance
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-
-        # Call method to test
-        exporter.download_shared_files()
+        with patch.object(SynologyOfficeExporter, '_process_item') as mock_process_item:
+            # Make the second file raise an exception when processed
+            def side_effect(item):
+                if item['file_id'] == '456':
+                    raise Exception('Test error')
+                return None
+            mock_process_item.side_effect = side_effect
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter.download_shared_files()
 
         # Verify all items were attempted to be processed, despite the exception
         self.assertEqual(mock_process_item.call_count, 3)
@@ -171,19 +172,17 @@ class TestDownload(unittest.TestCase):
         mock_process_item.assert_any_call({'file_id': '456', 'content_type': 'dir', 'name': 'folder1'})
         mock_process_item.assert_any_call({'file_id': '789', 'content_type': 'document', 'name': 'doc2'})
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
-    def test_exception_handling_mydrive(self, mock_process_directory):
+    def test_exception_handling_mydrive(self):
         """Test that exceptions in _process_directory do not stop execution."""
-        mock_process_directory.side_effect = Exception('Test error')
-
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter.download_mydrive_files()
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory:
+            mock_process_directory.side_effect = Exception('Test error')
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter.download_mydrive_files()
 
         # Verify _process_directory was called with correct parameters
         mock_process_directory.assert_called_once_with('/mydrive', 'My Drive')
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
-    def test_exception_handling_teamfolders(self, mock_process_directory):
+    def test_exception_handling_teamfolders(self):
         """Test that exceptions in one team folder do not prevent processing other folders."""
         self.mock_synd.get_teamfolder_info.return_value = {
             'Team Folder 1': '111',
@@ -191,15 +190,15 @@ class TestDownload(unittest.TestCase):
             'Team Folder 3': '333'
         }
 
-        # Make processing of 'Team Folder 2' raise an exception
-        def side_effect(file_id, name):
-            if file_id == '222':
-                raise Exception('Test error')
-            return None
-        mock_process_directory.side_effect = side_effect
-
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter.download_teamfolder_files()
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory:
+            # Make processing of 'Team Folder 2' raise an exception
+            def side_effect(file_id, name):
+                if file_id == '222':
+                    raise Exception('Test error')
+                return None
+            mock_process_directory.side_effect = side_effect
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter.download_teamfolder_files()
 
         # Verify all team folders were attempted to be processed
         self.assertEqual(mock_process_directory.call_count, 3)
@@ -207,53 +206,34 @@ class TestDownload(unittest.TestCase):
         mock_process_directory.assert_any_call('222', 'Team Folder 2')
         mock_process_directory.assert_any_call('333', 'Team Folder 3')
 
-    @patch('synology_drive_api.drive.SynologyDrive.download_synology_office_file')
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_exception_handling_download_synology(self, mock_save, mock_download):
+    def test_exception_handling_download_synology(self):
         """Test that exceptions during file download do not stop processing."""
-        mock_download.side_effect = Exception('Download failed')
-        self.mock_synd.download_synology_office_file = mock_download
+        with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save:
+            self.mock_synd.download_synology_office_file.side_effect = Exception('Download failed')
 
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter._process_document('123', 'path/to/test.osheet', hash=None)
+            exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
+            exporter._process_document('123', 'path/to/test.osheet', hash=None)
+        # Verify no exceptions were raised and the download was attempted.
 
-        mock_download.assert_called_once_with('123')
-        mock_save.assert_not_called()
-
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_exception_handling_download(self, mock_save):
-        """Test that exceptions during file download do not stop processing."""
-        self.mock_synd.download_synology_office_file.side_effect = Exception('Download failed')
-
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-        exporter._process_document('123', 'path/to/test.osheet', hash=None)
-
-        # Verify download was attempted
         self.mock_synd.download_synology_office_file.assert_called_once_with('123')
-        # Save should not have been called because download failed
         mock_save.assert_not_called()
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_download_history_skips_should_not_download_files(self, mock_save):
-        """Test that files with unchanged hash are not re-downloaded."""
-        self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
-
+    def test_download_history_skips_should_not_download_files(self,):
+        """Test that files already in download history are skipped."""
         download_history = MagicMock()
         download_history.should_download.return_value = False
-
         with SynologyOfficeExporter(self.mock_synd, download_history) as exporter:
             exporter._process_document('123', 'path/to/test.osheet', 'old-hash')
 
         # Verify that download was not attempted
         self.mock_synd.download_synology_office_file.assert_not_called()
-        mock_save.assert_not_called()
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_download_history_saves_files(self, mock_save):
+    def test_download_history_saves_files(self):
         """Test that new files are added to download history."""
         self.mock_synd.download_synology_office_file.return_value = BytesIO(b'new file data')
         download_history = MagicMock()
-        with SynologyOfficeExporter(self.mock_synd, download_history) as exporter:
+        with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save, \
+                SynologyOfficeExporter(self.mock_synd, download_history) as exporter:
             exporter._process_document('456', 'path/to/new.osheet', 'new-file-hash')
 
         # Verify that download was attempted
@@ -262,16 +242,14 @@ class TestDownload(unittest.TestCase):
         download_history.add_history_entry.assert_called_once_with(
             'path/to/new.osheet', '456', 'new-file-hash')
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_load_download_history(self, mock_save):
+    def test_load_download_history(self):
         """Test that custom download history storage is properly used."""
         # Create the mock download history instance
         download_history = MockDownloadHistory()
 
         # Use the custom history storage with the exporter
-        with SynologyOfficeExporter(self.mock_synd, download_history, output_dir='/test/dir',) as exporter:
-            # Verify that the exporter is using our custom history storage
-
+        with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'), \
+                SynologyOfficeExporter(self.mock_synd, download_history, output_dir='/test/dir',) as exporter:
             # Verify that lock and load methods were called during initialization
             self.assertTrue(download_history.lock_called)
             self.assertTrue(download_history.load_called)
@@ -293,11 +271,11 @@ class TestDownload(unittest.TestCase):
         self.assertTrue(download_history.save_called)
         self.assertTrue(download_history.unlock_called)
 
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter._process_directory')
-    def test_context_manager(self, mock_process):
+    def test_context_manager(self):
         """Test that context manager loads and saves download history."""
         mock_download_history = MockDownloadHistory()
-        with SynologyOfficeExporter(self.mock_synd, mock_download_history, output_dir='/test/dir') as exporter:
+        with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process, \
+                SynologyOfficeExporter(self.mock_synd, mock_download_history, output_dir='/test/dir') as exporter:
             # In the context, lock and load should have been called already
             self.assertTrue(mock_download_history.lock_called)
             self.assertTrue(mock_download_history.load_called)
@@ -305,36 +283,13 @@ class TestDownload(unittest.TestCase):
             self.assertFalse(mock_download_history.save_called)
             self.assertFalse(mock_download_history.unlock_called)
 
-        # Do something with the exporter
-        exporter.download_mydrive_files()
+            # Do something with the exporter
+            exporter.download_mydrive_files()
 
         # After the context, _save_download_history should have been called
         mock_process.assert_called_once()
         self.assertTrue(mock_download_history.save_called)
         self.assertTrue(mock_download_history.unlock_called)
-
-    @patch('synology_office_exporter.exporter.SynologyOfficeExporter.save_bytesio_to_file')
-    def test_force_download_ignores_history(self, mock_save):
-        """Test that force_download option downloads files regardless of history."""
-        self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
-
-        exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir='.', force_download=True)
-        exporter.download_history = {
-            'path/to/test.osheet': {
-                'file_id': '123',
-                'hash': 'abc123',
-                'path': 'path/to/test.osheet',
-                'download_time': '2023-01-01 12:00:00'
-            }
-        }
-
-        # Process a document that's already in the history with the same hash
-        # Even though it's in history with same hash, force_download should cause a redownload
-        exporter._process_document('123', 'path/to/test.osheet', 'abc123')
-
-        # Verify that download was attempted despite being in history
-        self.mock_synd.download_synology_office_file.assert_called_once_with('123')
-        mock_save.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -218,7 +218,7 @@ class TestDownload(unittest.TestCase):
         self.mock_synd.download_synology_office_file.assert_called_once_with('123')
         mock_save.assert_not_called()
 
-    def test_download_history_skips_should_not_download_files(self,):
+    def test_download_history_skips_should_not_download_files(self):
         """Test that files already in download history are skipped."""
         download_history = MagicMock()
         download_history.should_download.return_value = False

--- a/tests/test_download_history_file.py
+++ b/tests/test_download_history_file.py
@@ -151,11 +151,10 @@ class TestDownloadHistory(unittest.TestCase):
         mock_open.assert_called_once_with(os.path.join(self.output_dir, '.download_history.json'), 'r')
         mock_json_load.assert_called_once()
 
-    @patch('synology_office_exporter.exporter.DownloadHistoryFile.lock_history')
     @patch('os.path.exists')
     @patch('builtins.open', new_callable=unittest.mock.mock_open)
     @patch('json.load')
-    def test_load_download_history_invalid_magic(self, mock_json_load, mock_open, mock_exists, mock_lock):
+    def test_load_download_history_invalid_magic(self, mock_json_load, mock_open, mock_exists):
         """Test that an error is raised when the download history file has an incorrect magic number."""
         mock_exists.return_value = True
         # Simulate history data with an invalid magic number
@@ -178,11 +177,10 @@ class TestDownloadHistory(unittest.TestCase):
         mock_open.assert_called_once_with(os.path.join(self.output_dir, '.download_history.json'), 'r')
         mock_json_load.assert_called_once()
 
-    @patch('synology_office_exporter.exporter.DownloadHistoryFile.lock_history')
     @patch('os.path.exists')
     @patch('builtins.open', new_callable=unittest.mock.mock_open)
     @patch('json.load')
-    def test_load_download_history_invalid_json(self, mock_json_load, mock_open, mock_exists, mock_lock):
+    def test_load_download_history_invalid_json(self, mock_json_load, mock_open, mock_exists):
         """Test that an error is raised when the download history file is corrupt."""
         mock_exists.return_value = True
         # Simulate an error caused by invalid JSON

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -59,17 +59,10 @@ class TestExporter(unittest.TestCase):
         # Verify content was written
         mock_file_open().write.assert_called_once_with(test_content)
 
-    @patch('os.path.exists')
-    @patch('builtins.open', new_callable=mock_open)
-    @patch('json.load')
-    def test_process_document_tracking(self, mock_json_load, mock_file_open, mock_path_exists):
+    def test_process_document_tracking(self):
         """Test that documents are properly tracked for deletion detection."""
-        mock_path_exists.return_value = True
-        mock_json_load.return_value = {}
-
         # Mock BytesIO for download
-        mock_data = BytesIO(b'test content')
-        self.mock_synd.download_synology_office_file.return_value = mock_data
+        self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test content')
 
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file'):
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -81,8 +81,7 @@ class TestFileLockIntegration(unittest.TestCase):
         """Clean up temporary directory."""
         self.temp_dir.cleanup()
 
-    @patch('synology_office_exporter.download_history.DownloadHistoryFile.load_history')
-    def test_concurrent_access_prevention(self, mock_load):
+    def test_concurrent_access_prevention(self):
         """Test that a second instance cannot acquire the lock when first one holds it."""
         # First instance
         download_history = DownloadHistoryFile(output_dir=self.temp_dir.name)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -115,8 +115,7 @@ class TestStats(unittest.TestCase):
         }
 
         # Set up the mock
-        mock_data = BytesIO(b'test data')
-        self.mock_synd.download_synology_office_file.return_value = mock_data
+        self.mock_synd.download_synology_office_file.return_value = BytesIO(b'test data')
 
         # Execute the test
         with patch.object(SynologyOfficeExporter, 'save_bytesio_to_file') as mock_save:


### PR DESCRIPTION
Cleaned up tests around mocks.

- Remove unnecessary mocks.
- Replace global function patching with context-based `patch.object`
- Improve test structure by using separate test methods for different scenarios

