### PR TITLE
Add function to get stat info from SynologyOfficeExporter

### DIFF
--- a/synology_office_exporter/cli.py
+++ b/synology_office_exporter/cli.py
@@ -26,7 +26,6 @@ Authentication:
 
 import argparse
 import getpass
-import io
 import logging
 import os
 import sys
@@ -97,17 +96,17 @@ def main():  # noqa: D103
         # Connect to Synology Drive
         with SynologyDriveEx(username, password, server, dsm_version='7') as synd:
             # Create and use the downloader
-            stat_buf = io.StringIO()
-
-            # TODO: Encapsulate the logic of creating the download history file
-            # and the exporter in a function or class method
             download_history = DownloadHistoryFile(output_dir=args.output, force_download=args.force)
             with SynologyOfficeExporter(synd, output_dir=args.output, force_download=args.force,
-                                        stat_buf=stat_buf, download_history_storage=download_history) as exporter:
+                                        download_history_storage=download_history) as exporter:
                 exporter.download_mydrive_files()
                 exporter.download_shared_files()
                 exporter.download_teamfolder_files()
-            print(stat_buf.getvalue())
+
+            # Print summary of export
+            print("\n===== Download Results Summary =====\n")
+            print(exporter.get_summary())
+            print("=====================================")
 
         logging.info('Done!')
         return 0

--- a/synology_office_exporter/exporter.py
+++ b/synology_office_exporter/exporter.py
@@ -21,7 +21,7 @@ Requirements:
 See cli.py for command line usage instructions.
 """
 
-from io import BytesIO, StringIO
+from io import BytesIO
 import logging
 import os
 import sys
@@ -58,7 +58,7 @@ class SynologyOfficeExporter:
     """
 
     def __init__(self, synd: SynologyDriveEx, download_history_storage: DownloadHistoryFile,
-                 output_dir: str = '.', force_download: bool = False, stat_buf: StringIO = None):
+                 output_dir: str = '.', force_download: bool = False):
         """
         Initialize the SynologyOfficeExporter with the given parameters.
 
@@ -67,11 +67,9 @@ class SynologyOfficeExporter:
             download_history_storage: DownloadHistoryFile instance for tracking download history
             output_dir: Directory where converted files will be saved
             force_download: If True, files will be downloaded regardless of download history
-            stat_buf: StringIO buffer to write statistics output
         """
         self.synd = synd
         self.output_dir = output_dir
-        self.stat_buf = stat_buf
 
         # Initialize history storage
         self.__history_storage = download_history_storage
@@ -130,8 +128,6 @@ class SynologyOfficeExporter:
             raise
         finally:
             self.__history_storage.unlock_history()
-
-        self._dump_summary()
 
     def _remove_deleted_files(self):
         """
@@ -381,20 +377,21 @@ class SynologyOfficeExporter:
         with open(path, 'wb') as f:
             f.write(data.getvalue())
 
-    def _dump_summary(self):
+    def get_summary(self) -> str:
         """
-        Dump statistics for the execution results.
+        Get a summary of the download statistics.
 
-        This method writes a summary of the operation to the stat_buf if one was provided,
-        including counts of found, skipped, downloaded, and deleted files.
+        This method returns a formatted string containing the counts of found, skipped,
+        downloaded, and deleted files.
+        Returns:
+            str: A summary of the download statistics.
         """
-        if self.stat_buf is not None:
-            self.stat_buf.write('\n===== Download Results Summary =====\n\n')
-            self.stat_buf.write(f'Total files found for backup: {self.total_found_files}\n')
-            self.stat_buf.write(f'Files skipped: {self.skipped_files}\n')
-            self.stat_buf.write(f'Files downloaded: {self.downloaded_files}\n')
-            self.stat_buf.write(f'Files deleted: {self.deleted_files}\n')
-            self.stat_buf.write('=====================================\n')
+        return (
+            f'Total files found for backup: {self.total_found_files}\n'
+            f'Files skipped: {self.skipped_files}\n'
+            f'Files downloaded: {self.downloaded_files}\n'
+            f'Files deleted: {self.deleted_files}\n'
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,13 +1,16 @@
 """
-Tests for the main SynologyOfficeExporter class.
+Tests for the SynologyOfficeExporter class
 """
 
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
-from io import BytesIO, StringIO
+from unittest.mock import MagicMock, patch, mock_open
+from io import BytesIO
 import os
+import tempfile
+import shutil
 
 from synology_office_exporter.exporter import SynologyOfficeExporter
+from synology_office_exporter.download_history import DownloadHistoryFile
 from tests.mock_download_history import MockDownloadHistory
 
 
@@ -15,10 +18,26 @@ class TestExporter(unittest.TestCase):
     """Test suite for the SynologyOfficeExporter class."""
 
     def setUp(self):
-        """Set up test environment before each test."""
-        # Create a mock SynologyDriveEx instance
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.temp_dir, "output")
+        self.history_file = os.path.join(self.temp_dir, "history.json")
+
+        # Create mocks
         self.mock_synd = MagicMock()
-        self.output_dir = '/tmp/synology_office_exports'
+        self.history_storage = DownloadHistoryFile(self.history_file)
+
+        # Initialize the exporter
+        self.exporter = SynologyOfficeExporter(
+            synd=self.mock_synd,
+            download_history_storage=self.history_storage,
+            output_dir=self.output_dir
+        )
+
+    def tearDown(self):
+        """Tear down test fixtures"""
+        # Remove temp directory
+        shutil.rmtree(self.temp_dir)
 
     def test_convert_synology_to_ms_office_filename(self):
         """Test conversion of Synology Office filenames to MS Office filenames."""
@@ -83,27 +102,28 @@ class TestExporter(unittest.TestCase):
             # Verify the file ID was added to the tracking set
             self.assertIn('/path/to/document.odoc', exporter.current_file_paths)
 
-    def test_stat_buf(self):
-        """Test that statistics are correctly written to the provided buffer."""
-        stat_buf = StringIO()
-
-        with SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), stat_buf=stat_buf,
+    def test_statistics_tracking(self):
+        """Test that statistics are correctly tracked and can be retrieved via get_summary."""
+        # Create the exporter
+        with SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(),
                                     output_dir=self.output_dir) as exporter:
+            # Set the statistics values
             exporter.total_found_files = 3
             exporter.skipped_files = 2
             exporter.downloaded_files = 1
             exporter.deleted_files = 4
 
-        # Verify output matches expected format
-        self.assertEqual(
-            stat_buf.getvalue(),
-            '\n===== Download Results Summary =====\n\n'
-            'Total files found for backup: 3\n'
-            'Files skipped: 2\n'
-            'Files downloaded: 1\n'
-            'Files deleted: 4\n'
-            '=====================================\n'
-        )
+            # Get the summary
+            summary = exporter.get_summary()
+
+            # Verify the summary matches the expected format
+            expected_summary = (
+                'Total files found for backup: 3\n'
+                'Files skipped: 2\n'
+                'Files downloaded: 1\n'
+                'Files deleted: 4\n'
+            )
+            self.assertEqual(summary, expected_summary)
 
     def test_download_mydrive_files_with_exception(self):
         exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory(), output_dir=self.output_dir)
@@ -169,6 +189,23 @@ class TestExporter(unittest.TestCase):
         mock_process_document.assert_called_once_with(
             'file_id_1', '/path/to/document.odoc', 'hash1'
         )
+
+    def test_get_summary(self):
+        """Test that get_summary returns correct statistics"""
+        # Set up some statistics
+        self.exporter.total_found_files = 10
+        self.exporter.skipped_files = 3
+        self.exporter.downloaded_files = 5
+        self.exporter.deleted_files = 2
+
+        # Get summary
+        summary = self.exporter.get_summary()
+
+        # Check that summary contains all statistics
+        self.assertIn("Total files found for backup: 10", summary)
+        self.assertIn("Files skipped: 3", summary)
+        self.assertIn("Files downloaded: 5", summary)
+        self.assertIn("Files deleted: 2", summary)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Instead of using __exit__ to write stat infomration implicitly, add get_summary function to retrieve statistics from SynologyOfficeExporter class.