### PR TITLE
Add download_files method to streamline the file download process

### DIFF
--- a/synology_office_exporter/cli.py
+++ b/synology_office_exporter/cli.py
@@ -99,9 +99,7 @@ def main():  # noqa: D103
             download_history = DownloadHistoryFile(output_dir=args.output, force_download=args.force)
             with SynologyOfficeExporter(synd, output_dir=args.output, force_download=args.force,
                                         download_history_storage=download_history) as exporter:
-                exporter.download_mydrive_files()
-                exporter.download_shared_files()
-                exporter.download_teamfolder_files()
+                exporter.download_files()
 
             # Print summary of export
             print("\n===== Download Results Summary =====\n")

--- a/synology_office_exporter/exporter.py
+++ b/synology_office_exporter/exporter.py
@@ -164,7 +164,7 @@ class SynologyOfficeExporter:
 
         logging.info(f'Removed {self.deleted_files} files that were deleted from the NAS')
 
-    def download_mydrive_files(self):
+    def _download_mydrive_files(self):
         """
         Download and process all Synology Office files from the user's personal My Drive.
 
@@ -181,7 +181,18 @@ class SynologyOfficeExporter:
             logging.error(f'Error downloading My Drive files: {e}')
             self.had_exceptions = True
 
-    def download_shared_files(self):
+    def download_files(self):
+        """
+        Download and process all Synology Office files.
+
+        This method is a wrapper that calls the individual download methods for
+        My Drive, shared files, and team folders.
+        """
+        self._download_mydrive_files()
+        self._download_shared_files()
+        self._download_teamfolder_files()
+
+    def _download_shared_files(self):
         """
         Download and process all Synology Office files that are shared with the user.
 
@@ -203,7 +214,7 @@ class SynologyOfficeExporter:
             logging.error(f'Error accessing shared files: {e}')
             self.had_exceptions = True
 
-    def download_teamfolder_files(self):
+    def _download_teamfolder_files(self):
         """
         Download and process all Synology Office files from team folders.
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -63,7 +63,7 @@ class TestDownload(unittest.TestCase):
 
         with patch.object(SynologyOfficeExporter, '_process_item') as mock_process_item:
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-            exporter.download_shared_files()
+            exporter._download_shared_files()
 
         # Verify _process_item was called for each shared item
         self.assertEqual(mock_process_item.call_count, 2)
@@ -81,7 +81,7 @@ class TestDownload(unittest.TestCase):
 
         with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory:
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-            exporter.download_teamfolder_files()
+            exporter._download_teamfolder_files()
 
         # Verify _process_directory was called for each team folder
         self.assertEqual(mock_process_directory.call_count, 2)
@@ -144,7 +144,7 @@ class TestDownload(unittest.TestCase):
     def test_download_mydrive_files(self, mock_process_directory):
         exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
 
-        exporter.download_mydrive_files()
+        exporter._download_mydrive_files()
         mock_process_directory.assert_called_once_with('/mydrive', 'My Drive')
 
     def test_exception_handling_shared_files(self):
@@ -164,7 +164,7 @@ class TestDownload(unittest.TestCase):
                 return None
             mock_process_item.side_effect = side_effect
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-            exporter.download_shared_files()
+            exporter._download_shared_files()
 
         # Verify all items were attempted to be processed, despite the exception
         self.assertEqual(mock_process_item.call_count, 3)
@@ -177,7 +177,7 @@ class TestDownload(unittest.TestCase):
         with patch.object(SynologyOfficeExporter, '_process_directory') as mock_process_directory:
             mock_process_directory.side_effect = Exception('Test error')
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-            exporter.download_mydrive_files()
+            exporter._download_mydrive_files()
 
         # Verify _process_directory was called with correct parameters
         mock_process_directory.assert_called_once_with('/mydrive', 'My Drive')
@@ -198,7 +198,7 @@ class TestDownload(unittest.TestCase):
                 return None
             mock_process_directory.side_effect = side_effect
             exporter = SynologyOfficeExporter(self.mock_synd, MockDownloadHistory())
-            exporter.download_teamfolder_files()
+            exporter._download_teamfolder_files()
 
         # Verify all team folders were attempted to be processed
         self.assertEqual(mock_process_directory.call_count, 3)
@@ -284,7 +284,7 @@ class TestDownload(unittest.TestCase):
             self.assertFalse(mock_download_history.unlock_called)
 
             # Do something with the exporter
-            exporter.download_mydrive_files()
+            exporter._download_mydrive_files()
 
         # After the context, _save_download_history should have been called
         mock_process.assert_called_once()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -124,7 +124,7 @@ class TestExporter(unittest.TestCase):
         # Make list_folder raise an exception
         self.mock_synd.list_folder.side_effect = Exception('Network error')
 
-        exporter.download_mydrive_files()
+        exporter._download_mydrive_files()
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_shared_files_with_exception(self):
@@ -133,7 +133,7 @@ class TestExporter(unittest.TestCase):
         # Make list_folder raise an exception
         self.mock_synd.shared_with_me.side_effect = Exception('Network error')
 
-        exporter.download_shared_files()
+        exporter._download_shared_files()
         self.assertTrue(exporter.had_exceptions)
 
     def test_download_teamfolder_files_with_exception(self):
@@ -142,7 +142,7 @@ class TestExporter(unittest.TestCase):
         # Make list_folder raise an exception
         self.mock_synd.get_teamfolder_info.side_effect = Exception('Network error')
 
-        exporter.download_teamfolder_files()
+        exporter._download_teamfolder_files()
         self.assertTrue(exporter.had_exceptions)
 
     def test_process_document_with_exception(self):


### PR DESCRIPTION
This commit introduces a new download_files() method in SynologyOfficeExporter class that serves as a wrapper to simplify the API by calling the individual download methods for My Drive, shared files, and team folders in a single operation. This change improves usability by reducing the amount of code required to perform a complete download operation.